### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/worlds_worst_operator/action_sets/common_actions.py
+++ b/worlds_worst_operator/action_sets/common_actions.py
@@ -4,7 +4,7 @@ from dataclasses import fields
 from typing import Dict, Tuple, List
 
 import boto3
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 try:
     from database_ops import get_player

--- a/worlds_worst_operator/operator.py
+++ b/worlds_worst_operator/operator.py
@@ -11,7 +11,7 @@ from dataclasses import asdict
 from typing import Dict, Any, Callable, Tuple
 
 import boto3
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 try:
     from database_ops import create_player, update_player, verify_player

--- a/worlds_worst_operator/requirements.txt
+++ b/worlds_worst_operator/requirements.txt
@@ -1,3 +1,2 @@
 boto3
-fuzzywuzzy
-python-Levenshtein
+rapidfuzz


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy